### PR TITLE
Fix repository bugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-paginate"
-  # gem "jekyll-sitemap"
+  gem "jekyll-sitemap"
   gem "jekyll-gist"
   # gem "jekyll-feed"
   gem "jemoji"

--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,7 @@ plugins:
   - jemoji
   - jekyll-include-cache
   - jekyll-redirect-from
+  - jekyll-remote-theme
 
 author:
   name   : "지적인 낙관주의자"
@@ -89,7 +90,7 @@ footer:
       url: "https://github.com/a7420174"
     - label: "Instagram"
       icon: "fab fa-fw fa-instagram"
-      url: "https://instagram.com/hail.korean"
+      url: "https://instagram.com/hail.korea"
 
 defaults:
   # _posts
@@ -132,7 +133,7 @@ google:
   search_engine_id: 002af1359f8280c0b
 
 # google_site_verification: "VIq0jo72Wq4qsYDINXGyrt-aIYnZmiyGJe_MdnWHd0A"
-google-site-verification: 'naTbEU34Au3P9nZf0TzuWgx9zpkCXp2YR5Skt5UlUIk'
+google_site_verification: 'naTbEU34Au3P9nZf0TzuWgx9zpkCXp2YR5Skt5UlUIk'
 naver_site_verification: '66845c8a16eb57bb7f92fa8ce757fe6cca1d9a2c'
 
 analytics:


### PR DESCRIPTION
Correct Google Site Verification key, fix Instagram URL typo, and align Jekyll plugins for GitHub Pages compatibility.

The Google Site Verification key was misnamed, preventing proper verification. `jekyll-sitemap` was enabled in `_config.yml` but commented out in `Gemfile`, and `jekyll-remote-theme` is added to `_config.yml` to ensure GitHub Pages correctly builds with remote themes and sitemaps.

---
<a href="https://cursor.com/background-agent?bcId=bc-bec41803-217f-4f81-815c-1d2bd83d49a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bec41803-217f-4f81-815c-1d2bd83d49a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

